### PR TITLE
Fix PostComponent handling

### DIFF
--- a/examples/PrintNumbers.kscr
+++ b/examples/PrintNumbers.kscr
@@ -25,6 +25,11 @@ public class PrintNumbers implements Throwable {
         
         //start = "abc";
         
+        str canonical = stdio.getType().getCanonicalName();
+        str fullDetailed = stdio.getType().getFullDetailedName();
+        stdio <<- canonical + " len:" + canonical.length() + endl;
+        stdio <<- fullDetailed + " len:" + fullDetailed.length() + endl;
+        
         // test shorthand ops
         // TODO: make parentheses for parsing order obsolete (-> antlr grammar order)
         stdio <<- "24 (24) = " + (end) + " (" + end + ")" + endl;

--- a/kscr-compiler/KScr/Compiler/Code/ExpressionVisitor.cs
+++ b/kscr-compiler/KScr/Compiler/Code/ExpressionVisitor.cs
@@ -164,14 +164,14 @@ public class ExpressionVisitor : AbstractVisitor<StatementComponent>
     {
         var expr = VisitExpression(context.expr());
         var memberName = context.idPart().GetText();
-        expr.PostComponent = new StatementComponent
+        expr.AppendPostComponent(new StatementComponent
         {
             Type = StatementComponentType.Expression,
             CodeType = BytecodeType.Call,
             Arg = memberName,
             SubStatement = VisitArguments(context.arguments()),
             SourcefilePosition = ToSrcPos(context.idPart())
-        };
+        });
         bool isExtCall = expr.CodeType is BytecodeType.ExpressionVariable or BytecodeType.LiteralString
             or BytecodeType.LiteralRange or BytecodeType.LiteralNumeric or BytecodeType.LiteralTrue
             or BytecodeType.LiteralFalse or BytecodeType.TypeExpression;

--- a/kscr-core/Bytecode/Modifier.cs
+++ b/kscr-core/Bytecode/Modifier.cs
@@ -17,7 +17,8 @@ public enum MemberModifier : uint
     Syncronized = 0x0200_0000,
     
     PS = Public | Static,
-    PSF = PS | Final
+    PF = Public | Final,
+    PSF = PS | PF
 }
 
 public static class ModifierMethods

--- a/kscr-core/Bytecode/Property.cs
+++ b/kscr-core/Bytecode/Property.cs
@@ -90,6 +90,7 @@ public sealed class Property : AbstractClassMember, IObjectRef
         set => Console.Error.WriteLine("Error: Property needs evaluation");
     }
 
+    public IObject? DummyObject => Value;
     public IClassInstance Type => ReturnType.ResolveType(Parent.DefaultInstance);
 
     public IObject this[RuntimeBase vm, Stack stack, int i]

--- a/kscr-core/Bytecode/Statement.cs
+++ b/kscr-core/Bytecode/Statement.cs
@@ -164,6 +164,14 @@ public class StatementComponent : IBytecode, IStatementComponent
     public StatementComponentType Type { get; set; }
     public BytecodeType CodeType { get; set; } = BytecodeType.Undefined;
 
+    public void AppendPostComponent(StatementComponent comp)
+    {
+        StatementComponent x = this;
+        while (x.PostComponent != null) 
+            x = x.PostComponent!;
+        x.PostComponent = comp;
+    }
+
     public virtual Stack Evaluate(RuntimeBase vm, Stack stack)
     {
         IObjectRef? bak;
@@ -219,9 +227,12 @@ public class StatementComponent : IBytecode, IStatementComponent
                         if (vm.NativeRunner == null)
                             throw new FatalException("Cannot invoke native method; NativeRunner not loaded");
                         else
-                            vm.NativeRunner.InvokeMember(vm, stack, stack[Default][vm, stack, 0], mtd)
+                            vm.NativeRunner.InvokeMember(vm, stack, stack[Default]![vm, stack, 0], mtd)
                                 .Copy(Omg, Default);
-                    else mtd.Invoke(vm, stack, stack[Default][vm,stack,0], args: stack.Del!.AsArray(vm, stack));
+                    else
+                        mtd.Invoke(vm, stack,
+                            stack[Default]!.IsPipe ? stack[Default]!.DummyObject : stack[Default]![vm, stack, 0],
+                            args: stack.Del!.AsArray(vm, stack));
                 }
                 else if (cls.ClassMembers.FirstOrDefault(x => x.MemberType == ClassMemberType.Property && x.Name == Arg)
                          is Property prop)
@@ -457,7 +468,7 @@ public class StatementComponent : IBytecode, IStatementComponent
         }
 
         if (PostComponent != null)
-            PostComponent.Evaluate(vm, stack);
+            PostComponent.Evaluate(vm, stack); // todo fixme for some reason this modifies the parent stack
 
         return stack;
     }
@@ -577,7 +588,16 @@ public class StatementComponent : IBytecode, IStatementComponent
         }
 
         if (!ignorePostComp && PostComponent != null)
-            rtrn = PostComponent.OutputType(vm, symbols, this);
+            try
+            {
+                symbols.PushContext(rtrn.AsClass(vm));
+                rtrn = PostComponent.OutputType(vm, symbols, this);
+            }
+            finally
+            {
+                symbols.DropContext();
+            }
+
         return rtrn;
     }
 }

--- a/kscr-core/Model/IClass.cs
+++ b/kscr-core/Model/IClass.cs
@@ -73,10 +73,10 @@ public interface IClass : IClassInfo, IClassMember, IPackageMember
     new MemberModifier Modifier { get; }
     Class BaseClass { get; }
     ClassRef SelfRef { get; }
-    IEnumerable<IClassMember> ClassMembers => DeclaredMembers.Values.Concat(InheritedMembers);
+    IEnumerable<IClassMember> ClassMembers => DeclaredMembers.Values.Concat(InheritedMembers).Distinct();
 
     IEnumerable<IClassMember> InheritedMembers =>
-        Inheritors.Where(it => it != null).SelectMany(it => it.ClassMembers);
+        Inheritors.Where(it => it != null).SelectMany(it => it.ClassMembers).Distinct();
 
     IDictionary<string, IClassMember> DeclaredMembers { get; }
     IEnumerable<IClassInstance> Inheritors => Superclasses.Concat(Interfaces);

--- a/kscr-core/Model/ISymbolValidator.cs
+++ b/kscr-core/Model/ISymbolValidator.cs
@@ -10,6 +10,8 @@ public interface ISymbolValidator
     Symbol? FindSymbol(string name, ITypeInfo? type = null);
     T NextSymbolLevel<T>(string group, Func<T> task);
     IClass CurrentContext(RuntimeBase vm);
+    void PushContext(IClass cls);
+    IClass DropContext();
 }
 
 public enum SymbolType

--- a/kscr-core/RuntimeBase.cs
+++ b/kscr-core/RuntimeBase.cs
@@ -352,9 +352,14 @@ public abstract class RuntimeBase : IBytecodePort
 
     public sealed class StandardIORef : ObjectRef
     {
+        private readonly IObject _dummyObject;
+
         public StandardIORef(RuntimeBase vm) : base(Class.PipeType.CreateInstance(vm, Class.PipeType, Class.StringType))
         {
+            _dummyObject = new CodeObject(vm, Type);
         }
+
+        public override IObject DummyObject => _dummyObject;
 
         public override IEvaluable? ReadAccessor
         {

--- a/kscr-core/Std/Class.cs
+++ b/kscr-core/Std/Class.cs
@@ -57,7 +57,8 @@ public sealed class Class : AbstractPackageMember, IClass
     static Class()
     {
         VoidType = new Class(LibCorePackage, "void", true, MemberModifier.Public, ClassType.Interface);
-        TypeType = new Class(LibCorePackage, "type", true, MemberModifier.Public | MemberModifier.Final);
+        TypeType = new Class(LibCorePackage, "type", true, MemberModifier.Public | MemberModifier.Final)
+            { TypeParameters = { new TypeParameter("T") } };
         ObjectType = new Class(LibCorePackage, "object", true, MemberModifier.Public | MemberModifier.Native);
         EnumType = new Class(LibCorePackage, "enum", true, MemberModifier.Public | MemberModifier.Final | MemberModifier.Native)
             { TypeParameters = { new TypeParameter("T") } };
@@ -293,6 +294,16 @@ public sealed class Class : AbstractPackageMember, IClass
 
         #region Type Class
 
+        var getCanonicalName = new DummyMethod(TypeType, "getCanonicalName", MemberModifier.PF, StringType);
+        var getName = new DummyMethod(TypeType, "getName", MemberModifier.PF, StringType);
+        var getDetailedName = new DummyMethod(TypeType, "getDetailedName", MemberModifier.PF, StringType);
+        var getFullName = new DummyMethod(TypeType, "getFullName", MemberModifier.PF, StringType);
+        var getFullDetailedName = new DummyMethod(TypeType, "getFullDetailedName", MemberModifier.PF, StringType);
+        AddToClass(TypeType, getCanonicalName);
+        AddToClass(TypeType, getName);
+        AddToClass(TypeType, getDetailedName);
+        AddToClass(TypeType, getFullName);
+        AddToClass(TypeType, getFullDetailedName);
         TypeType._superclasses.Add(ObjectType.DefaultInstance);
 
         #endregion
@@ -327,8 +338,8 @@ public sealed class Class : AbstractPackageMember, IClass
             NumericIntType,
             new List<MethodParameter> { new() { Name = "data", Type = PipeType.TypeParameters[0] } });
 
-        AddToClass(PipeType, name);
-        AddToClass(PipeType, values);
+        AddToClass(PipeType, read);
+        AddToClass(PipeType, write);
         PipeType._interfaces.Add(VoidType.DefaultInstance);
 
         #endregion

--- a/kscr-core/Std/CodeObject.cs
+++ b/kscr-core/Std/CodeObject.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using System.Runtime.Intrinsics.X86;
 using KScr.Core.Bytecode;
 using KScr.Core.Exception;
 using KScr.Core.Model;
@@ -73,7 +74,7 @@ public sealed class CodeObject : NativeObj
                 stack[StackOutput.Default] = args[0]!.ObjectId == ObjectId ? vm.ConstantTrue : vm.ConstantFalse;
                 break;
             case "getType":
-                stack[StackOutput.Default] = Type.SelfRef;
+                stack[StackOutput.Default] = Class.TypeType.CreateInstance(vm, Class.TypeType, Type).SelfRef;
                 break;
             default: throw new FatalException("Method not implemented: " + member);
         }

--- a/kscr-core/Store/ClassStore.cs
+++ b/kscr-core/Store/ClassStore.cs
@@ -50,6 +50,7 @@ public class ClassRef : IObjectRef
         set => throw new NotSupportedException("Cannot change ClassRef");
     }
 
+    public IObject? DummyObject => Value;
     public IClassInstance Type => Class.TypeType.DefaultInstance;
 
     public IObject this[RuntimeBase vm, Stack stack, int i]

--- a/kscr-core/Store/ObjectStore.cs
+++ b/kscr-core/Store/ObjectStore.cs
@@ -70,7 +70,7 @@ public interface IObjectRef
     IEvaluable? WriteAccessor { get; set; }
 
     [Obsolete] IObject Value { get; set; }
-
+    IObject? DummyObject { get; }
     IClassInstance Type { get; }
     IObject this[RuntimeBase vm, Stack stack, int i] { get; set; }
 
@@ -115,7 +115,7 @@ public class ObjectRef : IObjectRef
     public ObjectRef(IClassInstance type, IObject value, bool constant = true) : this(type)
     {
         Value = value;
-        Constant = true;
+        Constant = constant;
     }
 
     public ObjectRef(IClassInstance type, [Range(1, int.MaxValue)] int len = 1)
@@ -128,6 +128,7 @@ public class ObjectRef : IObjectRef
         Refs = new IObject?[len];
     }
 
+    public virtual IObject? DummyObject => Value;
     public IClassInstance Type { get; }
 
     public int Length => Refs.Length;

--- a/kscr-core/Store/Stack.cs
+++ b/kscr-core/Store/Stack.cs
@@ -76,6 +76,7 @@ public sealed class StackOutputMapping : Dictionary<StackOutput, StackOutput>
 
 public sealed class Stack
 {
+    private readonly Guid _guid = Guid.NewGuid();
     public const string Separator = ".";
     public static readonly List<StackTraceException> StackTrace = new();
     private readonly CtxBlob _blob = null!;

--- a/kscr-system/Impl/Core.cs
+++ b/kscr-system/Impl/Core.cs
@@ -1,0 +1,31 @@
+﻿using KScr.Core;
+using KScr.Core.Model;
+using KScr.Core.Std;
+using KScr.Core.Store;
+using String = KScr.Core.Std.String;
+
+namespace KScr.Native.System.Impl;
+
+[NativeImpl(Package = "org.comroid.kscr.core", ClassName = "type")]
+public class Type
+{
+    [NativeImpl]
+    public static IObjectRef getCanonicalName(RuntimeBase vm, Stack stack, IObject target, params IObject[] args) =>
+        String.Instance(vm, (target as IClassInstance)!.CanonicalName);
+    
+    [NativeImpl]
+    public static IObjectRef getName(RuntimeBase vm, Stack stack, IObject target, params IObject[] args) =>
+        String.Instance(vm, (target as IClassInstance)!.Name);
+    
+    [NativeImpl]
+    public static IObjectRef getDetailedName(RuntimeBase vm, Stack stack, IObject target, params IObject[] args) =>
+        String.Instance(vm, (target as IClassInstance)!.DetailedName);
+
+    [NativeImpl]
+    public static IObjectRef getFullName(RuntimeBase vm, Stack stack, IObject target, params IObject[] args) => 
+        String.Instance(vm, (target as IClassInstance)!.FullName);
+
+    [NativeImpl]
+    public static IObjectRef getFullDetailedName(RuntimeBase vm, Stack stack, IObject target, params IObject[] args) => 
+        String.Instance(vm, (target as IClassInstance)!.FullDetailedName);
+}


### PR DESCRIPTION
When using call chains, something is wrong about the way PostComponents are handled.

It seems like sometimes the parent stack is modified.